### PR TITLE
Their API supports different values

### DIFF
--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -10,7 +10,7 @@ use structs::Root;
 struct Config {
     #[envconfig(from = "DALIA_APIKEY", default = "REPLACE_ME")]
     pub api_key: String,
-    #[envconfig(from = "TZ", default = "America/Chicago")]
+    #[envconfig(from = "TZ", default = "Chicago")]
     pub tz: String,
 }
 


### PR DESCRIPTION
With the general query parameter we're using they say this:

You may pass lat and lon, US zipcode, UK postcode, city name, IP, etc.

Fixing this to a default Central timezone city.