### PR TITLE
Add query parameters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -255,6 +255,7 @@ dependencies = [
  "actix-web",
  "env_logger",
  "envconfig",
+ "qstring",
  "reqwest",
  "serde",
 ]
@@ -1185,6 +1186,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "qstring"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d464fae65fff2680baf48019211ce37aaec0c78e9264c84a3e484717f965104e"
+dependencies = [
+ "percent-encoding",
 ]
 
 [[package]]

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -9,5 +9,6 @@ edition = "2021"
 actix-web = "4.3.1"
 env_logger = "0.10.0"
 envconfig = "0.10.0"
+qstring = "0.7.2"
 reqwest = { version = "0.11.18", features = ["json"] }
 serde = { version = "1.0.164", features = ["derive"] }

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -1,6 +1,7 @@
 use std::env;
 
-use actix_web::{get, middleware, web, App, HttpResponse, HttpServer, Responder};
+use actix_web::{get, middleware, web, App, HttpRequest, HttpResponse, HttpServer, Responder};
+use qstring::QString;
 
 mod structs;
 use envconfig::Envconfig;
@@ -35,6 +36,54 @@ async fn current_weather() -> impl Responder {
     HttpResponse::Ok().json(weather)
 }
 
+#[get("/weather")]
+async fn weather_fn(req : HttpRequest) -> impl Responder {
+    let query_str = req.query_string(); 
+    let qs = QString::from(query_str); // deconstruct the query string for parameters
+    let q_param_get = qs.get("q"); // REQUIRED q query param (zip .. TZ .. lat,long)
+    let d_param_get = qs.get("d"); // d days forecast param, accepts number of days
+
+    // If no q param was given, send a bad request response
+    if q_param_get.is_none() {
+        return HttpResponse::BadRequest().body("Invalid q param specificed.")
+
+    // Otherwise parse the request
+    } else {
+
+        // Get q & d params
+        let q_param = q_param_get.unwrap();
+        let mut _apiendpoint = "current";
+        let mut _forecast_query = String::new();
+
+        // If the days forecast is specified
+        // then change the endpoint and include the parameter
+        if !d_param_get.is_none(){
+            let d_param = d_param_get.unwrap();
+            _apiendpoint = "forecast";
+            _forecast_query = format!("&days={}", d_param);
+        }
+
+        // Get weatherapi response
+        let config = Config::init_from_env().unwrap();
+        let url = format!(
+            "https://api.weatherapi.com/v1/{endpoint}.json?key={apikey}&q={api_query}{forecast_query}",
+            endpoint = _apiendpoint,
+            apikey = config.api_key,
+            api_query = q_param,
+            forecast_query = _forecast_query
+        );
+
+        // Use struct
+        // TODO: This needs to be modified to include the new forecast
+        let response = reqwest::get(&url).await;
+        let weather: Root = response.unwrap().json().await.unwrap();
+
+        // Return weather results
+        return HttpResponse::Ok().json(weather)
+    }
+
+}
+
 async fn health() -> impl Responder {
     // TODO: Not in the scope of hackathon but leaving this here
     //       for the purpose of giving an example of adding additional routes
@@ -51,6 +100,7 @@ async fn main() -> std::io::Result<()> {
             .wrap(middleware::Logger::default())
             .service(version)
             .service(current_weather)
+            .service(weather_fn)
             .route("/health", web::get().to(health))
     })
     .bind(("127.0.0.1", 8080))?

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -46,41 +46,38 @@ async fn weather_fn(req : HttpRequest) -> impl Responder {
     // If no q param was given, send a bad request response
     if q_param_get.is_none() {
         return HttpResponse::BadRequest().body("Invalid q param specificed.")
-
-    // Otherwise parse the request
-    } else {
-
-        // Get q & d params
-        let q_param = q_param_get.unwrap();
-        let mut _apiendpoint = "current";
-        let mut _forecast_query = String::new();
-
-        // If the days forecast is specified
-        // then change the endpoint and include the parameter
-        if !d_param_get.is_none(){
-            let d_param = d_param_get.unwrap();
-            _apiendpoint = "forecast";
-            _forecast_query = format!("&days={}", d_param);
-        }
-
-        // Get weatherapi response
-        let config = Config::init_from_env().unwrap();
-        let url = format!(
-            "https://api.weatherapi.com/v1/{endpoint}.json?key={apikey}&q={api_query}{forecast_query}",
-            endpoint = _apiendpoint,
-            apikey = config.api_key,
-            api_query = q_param,
-            forecast_query = _forecast_query
-        );
-
-        // Use struct
-        // TODO: This needs to be modified to include the new forecast
-        let response = reqwest::get(&url).await;
-        let weather: Root = response.unwrap().json().await.unwrap();
-
-        // Return weather results
-        return HttpResponse::Ok().json(weather)
     }
+
+    // Get q & d params
+    let q_param = q_param_get.unwrap();
+    let mut _apiendpoint = "current";
+    let mut _forecast_query = String::new();
+
+    // If the days forecast is specified
+    // then change the endpoint and include the parameter
+    if !d_param_get.is_none(){
+        let d_param = d_param_get.unwrap();
+        _apiendpoint = "forecast";
+        _forecast_query = format!("&days={}", d_param);
+    }
+
+    // Get weatherapi response
+    let config = Config::init_from_env().unwrap();
+    let url = format!(
+        "https://api.weatherapi.com/v1/{endpoint}.json?key={apikey}&q={api_query}{forecast_query}",
+        endpoint = _apiendpoint,
+        apikey = config.api_key,
+        api_query = q_param,
+        forecast_query = _forecast_query
+    );
+
+    // Use struct
+    // TODO: This needs to be modified to include the new forecast
+    let response = reqwest::get(&url).await;
+    let weather: Root = response.unwrap().json().await.unwrap();
+
+    // Return weather results
+    return HttpResponse::Ok().json(weather)
 
 }
 


### PR DESCRIPTION
This adds a new endpoint and query parameters:

`/weather?q=<weatherapi query, zip, lat,long, tz>`
`/weather?q=<weatherapi query, zip, lat,long, tz>&d=<1-14 for the forecast api>`

The q query parameter is always required and is a passthrough for the weatherapi q query parameter. When the d query parameter is specified it will toggle to the /forecast endpoint and use the parameter value as "days" for that endpoint.

This MR does not yet modify the "Root" struct or create additional structs to handle relaying the forecasted json data, so it currently will not show up in the response.