### PR TITLE
Add in forecast struct

### DIFF
--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -1,10 +1,11 @@
 use std::env;
 
-use actix_web::{get, middleware, web, App, HttpResponse, HttpServer, Responder};
+use actix_web::{get, middleware, web, App, HttpRequest, HttpResponse, HttpServer, Responder};
+use qstring::QString;
 
 mod structs;
 use envconfig::Envconfig;
-use structs::CurrentWeather;
+use structs::Weather;
 
 #[derive(Envconfig)]
 struct Config {
@@ -30,7 +31,7 @@ async fn current_weather() -> impl Responder {
         timezone = config.tz
     );
     let response = reqwest::get(&url).await;
-    let mut weather: CurrentWeather = response.unwrap().json().await.unwrap();
+    let mut weather: Weather = response.unwrap().json().await.unwrap();
 
     if weather.location.tz_id.contains("America/") {
         weather.current.temp = Some(format!("{}F", weather.current.temp_f));
@@ -45,6 +46,49 @@ async fn current_weather() -> impl Responder {
     }
 
     HttpResponse::Ok().json(weather)
+}
+
+#[get("/weather")]
+async fn weather_fn(req: HttpRequest) -> impl Responder {
+    let query_str = req.query_string();
+    let qs = QString::from(query_str); // deconstruct the query string for parameters
+    let q_param_get = qs.get("q"); // REQUIRED q query param (zip .. TZ .. lat,long)
+    let d_param_get = qs.get("d"); // d days forecast param, accepts number of days
+
+    // If no q param was given, send a bad request response
+    if q_param_get.is_none() {
+        return HttpResponse::BadRequest().body("Invalid q param specificed.");
+    }
+
+    // Get q & d params
+    let q_param = q_param_get.unwrap();
+    let mut _apiendpoint = "current";
+    let mut _forecast_query = String::new();
+
+    // If the days forecast is specified
+    // then change the endpoint and include the parameter
+    if !d_param_get.is_none() {
+        let d_param = d_param_get.unwrap();
+        _apiendpoint = "forecast";
+        _forecast_query = format!("&days={}", d_param);
+    }
+
+    // Get weatherapi response
+    let config = Config::init_from_env().unwrap();
+    let url = format!(
+        "https://api.weatherapi.com/v1/{endpoint}.json?key={apikey}&q={api_query}{forecast_query}",
+        endpoint = _apiendpoint,
+        apikey = config.api_key,
+        api_query = q_param,
+        forecast_query = _forecast_query
+    );
+
+    // Use struct
+    let response = reqwest::get(&url).await;
+    let weather: Weather = response.unwrap().json().await.unwrap();
+
+    // Return weather results
+    return HttpResponse::Ok().json(weather);
 }
 
 async fn health() -> impl Responder {
@@ -63,6 +107,7 @@ async fn main() -> std::io::Result<()> {
             .wrap(middleware::Logger::default())
             .service(version)
             .service(current_weather)
+            .service(weather_fn)
             .route("/health", web::get().to(health))
     })
     .bind(("127.0.0.1", 8080))?

--- a/api/src/structs.rs
+++ b/api/src/structs.rs
@@ -2,15 +2,15 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct CurrentWeather {
-    pub location: CurrentLocation,
+pub struct Weather {
+    pub location: Location,
     pub current: Current,
-    pub forecast: Option<Forecast>
+    pub forecast: Option<Forecast>,
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct CurrentLocation {
+pub struct Location {
     pub name: String,
     pub region: String,
     pub country: String,
@@ -84,19 +84,18 @@ pub struct Current {
 pub struct Condition {
     pub text: String,
     pub icon: String,
-    pub code: i64,
+    pub code: f64,
 }
-
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Forecast {
-    pub forecastday: Vec<Forecastday>,
+    pub forecastday: Vec<ForecastDay>,
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct Forecastday {
+pub struct ForecastDay {
     pub date: String,
     #[serde(rename = "date_epoch")]
     pub date_epoch: f64,
@@ -176,7 +175,7 @@ pub struct Hour {
     pub temp_f: f64,
     #[serde(rename = "is_day")]
     pub is_day: f64,
-    pub condition: Condition2,
+    pub condition: Condition,
     #[serde(rename = "wind_mph")]
     pub wind_mph: f64,
     #[serde(rename = "wind_kph")]
@@ -228,12 +227,4 @@ pub struct Hour {
     #[serde(rename = "gust_kph")]
     pub gust_kph: f64,
     pub uv: f64,
-}
-
-#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct Condition2 {
-    pub text: String,
-    pub icon: String,
-    pub code: f64,
 }

--- a/api/src/structs.rs
+++ b/api/src/structs.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 pub struct CurrentWeather {
     pub location: CurrentLocation,
     pub current: Current,
+    pub forecast: Option<Forecast>
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -84,4 +85,155 @@ pub struct Condition {
     pub text: String,
     pub icon: String,
     pub code: i64,
+}
+
+
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Forecast {
+    pub forecastday: Vec<Forecastday>,
+}
+
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Forecastday {
+    pub date: String,
+    #[serde(rename = "date_epoch")]
+    pub date_epoch: f64,
+    pub day: Day,
+    pub astro: Astro,
+    pub hour: Vec<Hour>,
+}
+
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Day {
+    #[serde(rename = "maxtemp_c")]
+    pub maxtemp_c: f64,
+    #[serde(rename = "maxtemp_f")]
+    pub maxtemp_f: f64,
+    #[serde(rename = "mintemp_c")]
+    pub mintemp_c: f64,
+    #[serde(rename = "mintemp_f")]
+    pub mintemp_f: f64,
+    #[serde(rename = "avgtemp_c")]
+    pub avgtemp_c: f64,
+    #[serde(rename = "avgtemp_f")]
+    pub avgtemp_f: f64,
+    #[serde(rename = "maxwind_mph")]
+    pub maxwind_mph: f64,
+    #[serde(rename = "maxwind_kph")]
+    pub maxwind_kph: f64,
+    #[serde(rename = "totalprecip_mm")]
+    pub totalprecip_mm: f64,
+    #[serde(rename = "totalprecip_in")]
+    pub totalprecip_in: f64,
+    #[serde(rename = "totalsnow_cm")]
+    pub totalsnow_cm: f64,
+    #[serde(rename = "avgvis_km")]
+    pub avgvis_km: f64,
+    #[serde(rename = "avgvis_miles")]
+    pub avgvis_miles: f64,
+    pub avghumidity: f64,
+    #[serde(rename = "daily_will_it_rain")]
+    pub daily_will_it_rain: f64,
+    #[serde(rename = "daily_chance_of_rain")]
+    pub daily_chance_of_rain: f64,
+    #[serde(rename = "daily_will_it_snow")]
+    pub daily_will_it_snow: f64,
+    #[serde(rename = "daily_chance_of_snow")]
+    pub daily_chance_of_snow: f64,
+    pub condition: Condition,
+    pub uv: f64,
+}
+
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Astro {
+    pub sunrise: String,
+    pub sunset: String,
+    pub moonrise: String,
+    pub moonset: String,
+    #[serde(rename = "moon_phase")]
+    pub moon_phase: String,
+    #[serde(rename = "moon_illumination")]
+    pub moon_illumination: String,
+    #[serde(rename = "is_moon_up")]
+    pub is_moon_up: f64,
+    #[serde(rename = "is_sun_up")]
+    pub is_sun_up: f64,
+}
+
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Hour {
+    #[serde(rename = "time_epoch")]
+    pub time_epoch: f64,
+    pub time: String,
+    #[serde(rename = "temp_c")]
+    pub temp_c: f64,
+    #[serde(rename = "temp_f")]
+    pub temp_f: f64,
+    #[serde(rename = "is_day")]
+    pub is_day: f64,
+    pub condition: Condition2,
+    #[serde(rename = "wind_mph")]
+    pub wind_mph: f64,
+    #[serde(rename = "wind_kph")]
+    pub wind_kph: f64,
+    #[serde(rename = "wind_degree")]
+    pub wind_degree: f64,
+    #[serde(rename = "wind_dir")]
+    pub wind_dir: String,
+    #[serde(rename = "pressure_mb")]
+    pub pressure_mb: f64,
+    #[serde(rename = "pressure_in")]
+    pub pressure_in: f64,
+    #[serde(rename = "precip_mm")]
+    pub precip_mm: f64,
+    #[serde(rename = "precip_in")]
+    pub precip_in: f64,
+    pub humidity: f64,
+    pub cloud: f64,
+    #[serde(rename = "feelslike_c")]
+    pub feelslike_c: f64,
+    #[serde(rename = "feelslike_f")]
+    pub feelslike_f: f64,
+    #[serde(rename = "windchill_c")]
+    pub windchill_c: f64,
+    #[serde(rename = "windchill_f")]
+    pub windchill_f: f64,
+    #[serde(rename = "heatindex_c")]
+    pub heatindex_c: f64,
+    #[serde(rename = "heatindex_f")]
+    pub heatindex_f: f64,
+    #[serde(rename = "dewpoint_c")]
+    pub dewpoint_c: f64,
+    #[serde(rename = "dewpoint_f")]
+    pub dewpoint_f: f64,
+    #[serde(rename = "will_it_rain")]
+    pub will_it_rain: f64,
+    #[serde(rename = "chance_of_rain")]
+    pub chance_of_rain: f64,
+    #[serde(rename = "will_it_snow")]
+    pub will_it_snow: f64,
+    #[serde(rename = "chance_of_snow")]
+    pub chance_of_snow: f64,
+    #[serde(rename = "vis_km")]
+    pub vis_km: f64,
+    #[serde(rename = "vis_miles")]
+    pub vis_miles: f64,
+    #[serde(rename = "gust_mph")]
+    pub gust_mph: f64,
+    #[serde(rename = "gust_kph")]
+    pub gust_kph: f64,
+    pub uv: f64,
+}
+
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Condition2 {
+    pub text: String,
+    pub icon: String,
+    pub code: f64,
 }


### PR DESCRIPTION
This adds in the forecast structure when using the `/weather?q=<query>&d=<days integer>` endpoint. However, that endpoint was recently removed in https://github.com/skarekrow/dalia/pull/12 and will need to be added back in.